### PR TITLE
Update dependencies in firmware/hello to fix build

### DIFF
--- a/firmware/hello/Cargo.toml
+++ b/firmware/hello/Cargo.toml
@@ -10,7 +10,7 @@ cortex-m-rt = "0.7.1"
 defmt = "0.3.1"
 defmt-rtt = "1.1.0"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
-rp-pico = "0.9.0"
+rp-pico = "0.8.0"
 
 [profile.release]
 debug = 2

--- a/firmware/hello/Cargo.toml
+++ b/firmware/hello/Cargo.toml
@@ -8,9 +8,9 @@ version = "0.1.0"
 cortex-m = "0.7.4"
 cortex-m-rt = "0.7.1"
 defmt = "0.3.1"
-defmt-rtt = "0.3.2"
+defmt-rtt = "1.1.0"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
-rp-pico = "0.3.0"
+rp-pico = "0.9.0"
 
 [profile.release]
 debug = 2


### PR DESCRIPTION
Updated outdated dependencies in `firmware/hello/Cargo.toml` as mentioned in #6 .

Changes:
- `defmt-rtt`: 0.3.2 -> 1.1.0
- `rp-pico`: 0.3.0 -> 0.8.0

I chose rp-pico 0.8.0 because it maintains better compatibility with the existing USB dependency tree (usb-device 0.2.x) used in this project.

I've confirmed that the build passes with these changes.
